### PR TITLE
Change spark server initialization to service

### DIFF
--- a/src/main/java/com/despegar/sparkjava/test/SparkServer.java
+++ b/src/main/java/com/despegar/sparkjava/test/SparkServer.java
@@ -21,6 +21,8 @@ import spark.Service;
 import spark.Spark;
 import spark.servlet.SparkApplication;
 
+import static spark.Service.ignite;
+
 /**
  * The server for running the test's {@link SparkApplication}
  * @author Fernando Wasylyszyn
@@ -32,6 +34,8 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
     private T sparkApplication;
     
     private int port;
+
+    private Service instance;
     
     private String protocolHostPort;
     
@@ -71,13 +75,19 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
      */
     @Override
     protected void before() throws Throwable {
-    	Spark.port(this.port);
+		instance = ignite();
+		instance.port(this.port);
+
     	this.sparkApplication = this.sparkApplicationClass.newInstance();
     	this.sparkApplication.init();
-    	Spark.awaitInitialization();
+		instance.awaitInitialization();
     }
-    
-    public GetMethod get(String path, boolean followRedirect) {
+
+	public Service getInstance() {
+		return instance;
+	}
+
+	public GetMethod get(String path, boolean followRedirect) {
 		return new GetMethod(this.protocolHostPort + path, followRedirect);
 	}
 	
@@ -115,7 +125,7 @@ public class SparkServer<T extends SparkApplication> extends ExternalResource {
     @Override
     protected void after() {
     	this.sparkApplication.destroy();
-    	Spark.stop();
+		instance.stop();
     }
     
 }

--- a/src/test/java/com/despegar/sparkjava/test/TestController.java
+++ b/src/test/java/com/despegar/sparkjava/test/TestController.java
@@ -1,9 +1,8 @@
 package com.despegar.sparkjava.test;
 
-import static spark.Spark.get;
-
 import spark.Request;
 import spark.Response;
+import spark.Service;
 
 /**
  * The class that defines a Spark Web Framework route
@@ -12,8 +11,8 @@ import spark.Response;
  */
 public class TestController {
 
-	public TestController() {
-		get("/test", (request, response) ->  this.testMethod(request, response));
+	public TestController(Service service) {
+		service.get("/test", (request, response) ->  this.testMethod(request, response));
 	}
 	
 	public String testMethod(Request request, Response response) {

--- a/src/test/java/com/despegar/sparkjava/test/TestControllerTest.java
+++ b/src/test/java/com/despegar/sparkjava/test/TestControllerTest.java
@@ -18,11 +18,11 @@ import spark.servlet.SparkApplication;
  */
 public class TestControllerTest {
 
-	public static class TestContollerTestSparkApplication implements SparkApplication {
+	public static class TestControllerTestSparkApplication implements SparkApplication {
 		@Override
 		public void init() {
 			System.out.println("Test application initialized");
-			new TestController();
+			new TestController(testServer.getInstance());
 		}
 
 		@Override
@@ -34,7 +34,7 @@ public class TestControllerTest {
 	}
 	
 	@ClassRule
-	public static SparkServer<TestContollerTestSparkApplication> testServer = new SparkServer<>(TestControllerTest.TestContollerTestSparkApplication.class, 4567);
+	public static SparkServer<TestControllerTestSparkApplication> testServer = new SparkServer<>(TestControllerTest.TestControllerTestSparkApplication.class, 4567);
 	
 	@Test
 	public void test() throws Exception {


### PR DESCRIPTION
In order to use spark-test in multiple unit test classes, the initialization of the spark server have to be changed by using the Service class provided by spark.

Problem by this implementation is the need of adjusting the route registration, as seen in the test classes.

I tested the changes with your test classes and in a different project, having three test classes.

This is a copy from https://github.com/despegar/spark-test/pull/17